### PR TITLE
Feature/optimize allocation

### DIFF
--- a/src/tokenizer/newmm_custom.rs
+++ b/src/tokenizer/newmm_custom.rs
@@ -22,7 +22,7 @@ use super::{
     dict_reader_custom::{create_default_dict, create_dict_trie, DictSource},
     tcc_custom,
     tokenizer_trait::Tokenizer,
-    trie_custom::{Trie,ListPrefix},
+    trie_custom::{Trie},
 };
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use binary_heap_plus::{BinaryHeap, MinComparator};
@@ -141,7 +141,7 @@ impl Newmm {
         } {
             if let Some(begin_position) = position_list.pop() {
                 let sub_text_prefix = text.slice_by_char_indice(begin_position, text.chars_len());
-                let prefixes = sub_text_prefix.prefix_from_trie(&custom_dict);
+                let prefixes = Trie::prefix_ref(sub_text_prefix, &custom_dict);
                 for word in prefixes {
                     let word_length = word.chars_len();
                     let end_position_candidate = begin_position + word_length;
@@ -209,7 +209,7 @@ impl Newmm {
                                 if valid_position.contains(&position) {
                                     let prefix = &text.slice_by_char_indice(position, text_length);
 
-                                    let list_of_prefixes = prefix.prefix_from_trie(&custom_dict);
+                                    let list_of_prefixes =Trie::prefix_ref(prefix, &custom_dict);
                                     let valid_word_filter = |word: &&[u8]| {
                                         let new_position = position + word.chars_len();
                                         let is_valid = valid_position.contains(&new_position);

--- a/src/tokenizer/newmm_custom.rs
+++ b/src/tokenizer/newmm_custom.rs
@@ -115,14 +115,14 @@ impl Newmm {
         panic!("something wrong");
     }
 
-    fn one_cut(input: &CustomStringBytesSlice, custom_dict: &Trie) -> Vec<CustomStringBytesVec> {
+    fn one_cut<'a,'b>(input: &'a CustomStringBytesSlice, custom_dict: &'b Trie) -> Vec<&'a CustomStringBytesSlice> {
         let text = input;
         let input_char_len = text.chars_len();
         let mut reused_queue: VecDeque<(usize, Vec<usize>)> = VecDeque::with_capacity(10);
         let mut graph_size: usize = 0;
         let mut graph: HashMap<CharacterIndex, Vec<CharacterIndex>> =
             HashMap::with_capacity(input_char_len / 100);
-        let mut result_str: Vec<CustomStringBytesVec> = Vec::with_capacity(input_char_len / 100);
+        let mut result_str: Vec<&CustomStringBytesSlice> = Vec::with_capacity(input_char_len / 100);
 
         // all position should be refered as character index
         let valid_position = tcc_custom::tcc_pos(input);
@@ -181,7 +181,7 @@ impl Newmm {
                         for position in group_of_end_position_candidate.iter().skip(1) {
                             let token = text.slice_by_char_indice(end_position, *position);
 
-                            result_str.push(Vec::from(token));
+                            result_str.push(token);
                             end_position = *position;
                         }
                     } else {
@@ -254,7 +254,7 @@ impl Newmm {
                             graph_size += 1;
                             let token = text.slice_by_char_indice(begin_position, end_position);
 
-                            result_str.push(Vec::from(token));
+                            result_str.push(token);
                             position_list.push(end_position);
                             existing_candidate.insert(end_position);
                         }
@@ -264,7 +264,7 @@ impl Newmm {
                             graph.insert(begin_position, graph_elem);
                             graph_size += 1;
                             let token = text.slice_by_char_indice(begin_position, end_position);
-                            result_str.push(Vec::from(token));
+                            result_str.push(token);
                             position_list.push(end_position);
                             existing_candidate.insert(end_position);
                         }
@@ -272,8 +272,6 @@ impl Newmm {
                 }
             }
         }
-
-        result_str.shrink_to_fit();
         result_str
     }
     pub fn internal_segment(
@@ -319,15 +317,15 @@ impl Newmm {
                     let mut token_max_index = 0;
                     let mut token_max_length = 0;
                     for (idx, token) in word_tokens.iter().enumerate() {
-                        if token.as_slice().chars_len() >= token_max_length {
-                            token_max_length = token.as_slice().chars_len();
+                        if token.chars_len() >= token_max_length {
+                            token_max_length = token.chars_len();
                             token_max_index = idx;
                         }
                     }
                     // choose the position that covers longest token
                     cut_pos = TEXT_SCAN_BEGIN;
                     for i in 0..token_max_index {
-                        cut_pos = cut_pos + word_tokens.get(i).unwrap().as_slice().chars_len();
+                        cut_pos = cut_pos + word_tokens.get(i).unwrap().chars_len();
                     }
                 }
                 txt_parts.push(txt.slice_by_char_indice(0, cut_pos).to_owned());

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -13,9 +13,7 @@ Rust Borrow Checker and this author's (Thanathip) little experience.
 
 Rust Code: Thanathip Suntorntip (Gorlph)
 */
-pub trait ListPrefix {
-    fn prefix_from_trie(&self, dict_trie: &Trie) -> Vec<&[u8]>;
-}
+
 #[derive(Debug)]
 pub struct TrieNode {
     children: HashMap<CustomStringBytesVec, Self>,
@@ -185,30 +183,5 @@ impl Trie {
     }
     pub fn amount_of_words(&self) -> usize {
         self.words.iter().count()
-    }
-}
-impl ListPrefix for &[u8] {
-    fn prefix_from_trie(&self, dict_trie: &Trie) -> Vec<&CustomStringBytesSlice> {
-        let mut result: Vec<&CustomStringBytesSlice> = Vec::with_capacity(100);
-        let prefix_cpy = self;
-        let mut current_index = 0;
-        let mut current_node_wrap = Some(&dict_trie.root);
-        while current_index < prefix_cpy.chars_len() {
-            let character = prefix_cpy.slice_by_char_indice(current_index, current_index + 1);
-            if let Some(current_node) = current_node_wrap {
-                if let Some(child) = current_node.find_child(character) {
-                    if child.end {
-                        let substring_of_prefix =
-                            prefix_cpy.slice_by_char_indice(0, current_index + 1);
-                        result.push(substring_of_prefix);
-                    }
-                    current_node_wrap = Some(child);
-                } else {
-                    break;
-                }
-            }
-            current_index = current_index + 1;
-        }
-        result
     }
 }

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -13,7 +13,9 @@ Rust Borrow Checker and this author's (Thanathip) little experience.
 
 Rust Code: Thanathip Suntorntip (Gorlph)
 */
-
+pub trait ListPrefix {
+    fn prefix_from_trie(&self,dict_trie:&Trie) -> Vec<&[u8]>;
+}
 #[derive(Debug)]
 pub struct TrieNode {
     children: HashMap<CustomStringBytesVec, Self>,
@@ -150,5 +152,30 @@ impl Trie {
     }
     pub fn amount_of_words(&self) -> usize {
         self.words.iter().count()
+    }
+}
+impl ListPrefix for &[u8]{
+    fn prefix_from_trie(&self,dict_trie:&Trie) -> Vec<&CustomStringBytesSlice> {
+        let mut result: Vec<&CustomStringBytesSlice> = Vec::with_capacity(100);
+        let prefix_cpy = self;
+        let mut current_index = 0;
+        let mut current_node_wrap = Some(&dict_trie.root);
+        while current_index < prefix_cpy.chars_len() {
+            let character = prefix_cpy.slice_by_char_indice(current_index, current_index + 1);
+            if let Some(current_node) = current_node_wrap {
+                if let Some(child) = current_node.find_child(character) {
+                    if child.end {
+                        let substring_of_prefix =
+                            prefix_cpy.slice_by_char_indice(0, current_index + 1);
+                        result.push(substring_of_prefix);
+                    }
+                    current_node_wrap = Some(child);
+                } else {
+                    break;
+                }
+            }
+            current_index = current_index + 1;
+        }
+        result
     }
 }


### PR DESCRIPTION
This PR aims to improve speed by reducing unnecessary memory allocation.

It's mostly done by changing return type of some crucial functions from Vec<u8> to &[u8] .  

Further and more proper benchmark is needed.  On my machine, this version push the performance to nearly 3x of py_newmm