### PR TITLE
Use .lock() instead of unnecessary std::io::BufReader. Thank Nui Naro…

### DIFF
--- a/nlpo3-cli/src/main.rs
+++ b/nlpo3-cli/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
 
         let newmm = Newmm::new(dict_path);
 
-        for line_opt in io::BufReader::new(io::stdin()).lines() {
+        for line_opt in io::stdin().lock().lines() {
             let cleaned_line = match line_opt {
                 Ok(line) => line.trim_end_matches('\n').to_string(),
                 Err(e) => panic!("Cannot read line {}", e),


### PR DESCRIPTION
…ngwet for pointing out.