### PR TITLE
Feature/change hash lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ bytecount = "0.6.2"
 lazy_static = "1.4.0"
 rayon = "1.5"
 regex = "1.4.6"
-smol_str = "0.1.17"
-
+anyhow = "1.0.42"
 
 [[test]]
 name = "basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,24 +13,25 @@ repository = "https://github.com/PyThaiNLP/nlpo3/"
 readme = "README.md"
 exclude = [".gitignore", ".github/*", "build_tools/*", "tests/*"]
 
-
+[profile.release]
+lto = true
+codegen-units = 1
 
 [lib]
 path = "src/lib.rs"
 # "cdylib" is necessary to produce a shared library for Python to import from.
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
 # to `use string_sum;` unless the "rlib" or "lib" crate type is also included.
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib","rlib"]
 
 [dependencies]
-ahash = "0.7.2"
 binary-heap-plus = "0.4.1"
 bytecount = "0.6.2"
 lazy_static = "1.4.0"
 rayon = "1.5"
 regex = "1.4.6"
 anyhow = "1.0.42"
-
+rustc-hash = "1.1.0"
 [[test]]
 name = "basic"
 path = "tests/test_tokenizer.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/PyThaiNLP/nlpo3/"
 documentation = "https://github.com/PyThaiNLP/nlpo3/"
 repository = "https://github.com/PyThaiNLP/nlpo3/"
 readme = "README.md"
-exclude = [".gitignore", ".github/*", "build_tools/*", "tests/*"]
+exclude = [".gitignore", ".github/*", "build_tools/*", "tests/*", "nlpo3-cli/*", "nlpo3-nodejs/*", "nlpo3-python/*"]
 
 [profile.release]
 lto = true
@@ -22,16 +22,18 @@ path = "src/lib.rs"
 # "cdylib" is necessary to produce a shared library for Python to import from.
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able
 # to `use string_sum;` unless the "rlib" or "lib" crate type is also included.
-crate-type = ["cdylib","rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+anyhow = "1.0.42"
 binary-heap-plus = "0.4.1"
 bytecount = "0.6.2"
 lazy_static = "1.4.0"
 rayon = "1.5"
 regex = "1.4.6"
-anyhow = "1.0.42"
 rustc-hash = "1.1.0"
+
+
 [[test]]
 name = "basic"
 path = "tests/test_tokenizer.rs"

--- a/src/fixed_bytes_str/four_bytes.rs
+++ b/src/fixed_bytes_str/four_bytes.rs
@@ -262,7 +262,7 @@ impl CustomString {
         let mut output_content: Vec<u8> = Vec::with_capacity(input.len() / 100);
         for index in 0..input.chars_len() {
             let extracted_bytes =
-                trim_to_std_utf8(&input.slice_by_char_indice(index, index + 1)).unwrap();
+                trim_to_std_utf8(input.slice_by_char_indice(index, index + 1)).unwrap();
             match extracted_bytes {
                 (None, None, None, Some(first_byte)) => {
                     output_content.push(first_byte);
@@ -293,7 +293,7 @@ impl CustomString {
         let mut output_content: Vec<u8> = Vec::with_capacity(input.len() / 100);
         for index in 0..input.chars_len() {
             let extracted_bytes =
-                trim_to_std_utf8(&input.slice_by_char_indice(index, index + 1)).unwrap();
+                trim_to_std_utf8(input.slice_by_char_indice(index, index + 1)).unwrap();
             match extracted_bytes {
                 (None, None, None, Some(first_byte)) => {
                     output_content.push(first_byte);
@@ -329,7 +329,7 @@ pub trait FixedCharsLengthByteSlice {
 
 impl FixedCharsLengthByteSlice for &CustomStringBytesSlice {
     fn slice_by_char_indice(&self, start: usize, end: usize) -> Self {
-        unsafe { &self.get_unchecked((start * BYTES_PER_CHAR)..(end * BYTES_PER_CHAR)) }
+        unsafe { self.get_unchecked((start * BYTES_PER_CHAR)..(end * BYTES_PER_CHAR)) }
     }
     fn chars_len(&self) -> usize {
         self.len() / BYTES_PER_CHAR
@@ -368,7 +368,7 @@ fn check_slice() {
     let ex: &[u8] = &[255, 255, 255, 255, 0, 255, 111, 0];
     assert_eq!(ex.slice_by_char_indice(0, 1), &[255, 255, 255, 255]);
     assert_eq!(ex.slice_by_char_indice(1, 2), &[0, 255, 111, 0]);
-    assert_eq!("".is_empty(), true);
+    assert!("".is_empty());
 }
 
 #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,5 +1,5 @@
-pub mod dict_reader_custom;
+mod dict_reader_custom;
 pub mod newmm_custom;
-pub mod tcc_custom;
+mod tcc_custom;
 pub mod tokenizer_trait;
-pub mod trie_custom;
+mod trie_custom;

--- a/src/tokenizer/newmm_custom.rs
+++ b/src/tokenizer/newmm_custom.rs
@@ -18,7 +18,6 @@ with heuristic graph size limit added to avoid exponential wait time.
 
 Rust implementation: ["Thanathip Suntorntip"]
 */
-// TODO: use slice_by_chars_indice on &[u8]
 use crate::fixed_bytes_str::four_bytes::{
     rfind_space_char_index, CustomString, FixedCharsLengthByteSlice, BYTES_PER_CHAR,
 };
@@ -159,7 +158,7 @@ impl Newmm {
         let mut result_str: Vec<&CustomStringBytesSlice> = Vec::with_capacity(input_char_len / 10);
 
         // all position should be refered as character index
-        let valid_position = tcc_custom::tcc_pos_quick(input);
+        let valid_position = tcc_custom::tcc_pos(input);
         let text_length = input_char_len;
         let mut position_list: BinaryHeap<CharacterIndex, MinComparator> = BinaryHeap::new_min();
         let mut existing_candidate: HashSet<CharacterIndex> = HashSet::default();

--- a/src/tokenizer/tcc_custom.rs
+++ b/src/tokenizer/tcc_custom.rs
@@ -10,7 +10,7 @@ Credits:
     * Python code: Korakot Chaovavanich
     * Rust Code Translation: Thanathip Suntorntip
 */
-use ahash::AHashSet as HashSet;
+use rustc_hash::FxHashSet as HashSet;
 use lazy_static::lazy_static;
 use regex::bytes::Regex;
 
@@ -65,9 +65,45 @@ lazy_static! {
     )
     .unwrap();
 }
+pub fn tcc_pos_quick(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize>{
+    let mut set: HashSet<usize> = HashSet::default();
+    set.reserve(custom_text_type.chars_len() / 10);
+    let mut txt = custom_text_type;
+    let mut position: usize = 0;
+    while !txt.is_empty() {
+        if let Some(result) = NON_LOOKAHEAD_TCC.find(txt) {
+            let mut matched = &txt[result.start()..result.end()];
+            let match_length = matched.len();
+            if LOOKAHEAD_TCC.is_match(matched) {
+                // trim one more char to the right.
+                let end_bytes_index = match_length - (1 * BYTES_PER_CHAR);
+                matched = &matched[0..end_bytes_index];
+                let segment_size = matched.chars_len();
+                position += segment_size;
+                set.insert(position);
+                txt = &txt[end_bytes_index..];
+            } else {
+                let segment_size = matched.chars_len();
+                position += segment_size;
+                set.insert(position);
+                let end_bytes_index = match_length;
+                txt = &txt[end_bytes_index..];
+            }
+        } else {
+            // not thai
+            let first_char = txt.slice_by_char_indice(0, 1);
+            let segment_size = first_char.chars_len();
+            position += segment_size;
+            set.insert(position);
+            txt = txt.slice_by_char_indice(1, txt.chars_len());
+        }
+    }
+    set
+}
 
 pub fn tcc_pos(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize> {
-    let mut set: HashSet<usize> = HashSet::with_capacity(custom_text_type.chars_len() / 10);
+    let mut set: HashSet<usize> = HashSet::default();
+    set.reserve(custom_text_type.chars_len() / 10);
     if custom_text_type.is_empty() {
         return set;
     } else {

--- a/src/tokenizer/tcc_custom.rs
+++ b/src/tokenizer/tcc_custom.rs
@@ -69,7 +69,7 @@ lazy_static! {
 pub fn tcc_pos(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize> {
     let mut set: HashSet<usize> = HashSet::with_capacity(custom_text_type.chars_len() / 10);
     if custom_text_type.is_empty() {
-        set
+        return set;
     } else {
         let mut position: usize = 0;
         let four_bytes_chars_segment = segment(custom_text_type);
@@ -78,8 +78,8 @@ pub fn tcc_pos(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize> {
             position += segment_size;
             set.insert(position);
         }
-        set
     }
+    set
 }
 
 pub fn segment(custom_text_type: &CustomStringBytesSlice) -> Vec<&CustomStringBytesSlice> {

--- a/src/tokenizer/tcc_custom.rs
+++ b/src/tokenizer/tcc_custom.rs
@@ -65,7 +65,7 @@ lazy_static! {
     )
     .unwrap();
 }
-pub fn tcc_pos_quick(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize>{
+pub fn tcc_pos(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize>{
     let mut set: HashSet<usize> = HashSet::default();
     set.reserve(custom_text_type.chars_len() / 10);
     let mut txt = custom_text_type;
@@ -101,28 +101,12 @@ pub fn tcc_pos_quick(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize
     set
 }
 
-pub fn tcc_pos(custom_text_type: &CustomStringBytesSlice) -> HashSet<usize> {
-    let mut set: HashSet<usize> = HashSet::default();
-    set.reserve(custom_text_type.chars_len() / 10);
-    if custom_text_type.is_empty() {
-        return set;
-    } else {
-        let mut position: usize = 0;
-        let four_bytes_chars_segment = segment(custom_text_type);
-        for segment in four_bytes_chars_segment.into_iter() {
-            let segment_size = segment.chars_len();
-            position += segment_size;
-            set.insert(position);
-        }
-    }
-    set
-}
-
-pub fn segment(custom_text_type: &CustomStringBytesSlice) -> Vec<&CustomStringBytesSlice> {
+#[allow(dead_code)]
+pub fn tcc_segment(custom_text_type: &CustomStringBytesSlice) -> Vec<&CustomStringBytesSlice> {
     let mut txt = custom_text_type;
     let mut tcc_result: Vec<&[u8]> = Vec::with_capacity(txt.len() / 10);
     while !txt.is_empty() {
-        if let Some(result) = NON_LOOKAHEAD_TCC.find(&txt) {
+        if let Some(result) = NON_LOOKAHEAD_TCC.find(txt) {
             let mut matched = &txt[result.start()..result.end()];
             let match_length = matched.len();
             if LOOKAHEAD_TCC.is_match(matched) {

--- a/src/tokenizer/tokenizer_trait.rs
+++ b/src/tokenizer/tokenizer_trait.rs
@@ -1,8 +1,11 @@
 /**
    This should be the only part exposed to lib.rs
 */
+use anyhow::Result as AnyResult;
 pub trait Tokenizer {
-    fn segment(&self, text: &str, safe: Option<bool>, parallel: Option<bool>) -> Vec<String>;
+    // I need help naming these two functions...
+    
+    fn segment(&self, text: &str, safe: Option<bool>, parallel: Option<bool>) -> AnyResult<Vec<String>>;
 
     fn segment_to_string(
         &self,

--- a/src/tokenizer/tokenizer_trait.rs
+++ b/src/tokenizer/tokenizer_trait.rs
@@ -1,11 +1,11 @@
-/**
-   This should be the only part exposed to lib.rs
-*/
 use anyhow::Result as AnyResult;
 pub trait Tokenizer {
-    // I need help naming these two functions...
-    
-    fn segment(&self, text: &str, safe: Option<bool>, parallel: Option<bool>) -> AnyResult<Vec<String>>;
+    fn segment(
+        &self,
+        text: &str,
+        safe: Option<bool>,
+        parallel: Option<bool>,
+    ) -> AnyResult<Vec<String>>;
 
     fn segment_to_string(
         &self,

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -2,7 +2,7 @@ use crate::fixed_bytes_str::four_bytes::{
     CustomString, CustomStringBytesSlice, CustomStringBytesVec, FixedCharsLengthByteSlice,
     BYTES_PER_CHAR,
 };
-use ahash::{AHashMap as HashMap, AHashSet as HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::BorrowMut;
 use std::iter::Iterator;
 /**
@@ -31,7 +31,7 @@ impl TrieNode {
     pub fn new() -> Self {
         Self {
             // text: None,
-            children: HashMap::with_capacity(100),
+            children: HashMap::default(),
             end: false,
         }
     }
@@ -118,7 +118,7 @@ pub struct Trie {
 impl Trie {
     pub fn new(words: &[CustomString]) -> Self {
         let mut instance = Self {
-            words: HashSet::with_capacity(words.len() / 10),
+            words: HashSet::default(),
             root: TrieNode::new(),
         };
         for word in words.iter() {
@@ -160,6 +160,7 @@ impl Trie {
 
        The only downside I can think about this function is its non-descriptive name..
     */
+
     pub fn prefix_ref<'p, 't>(
         prefix: &'p CustomStringBytesSlice,
         dict_trie: &'t Self,

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -76,7 +76,7 @@ impl TrieNode {
                 if char_count == 1 {
                     child.set_not_end();
                 }
-                child.remove_word_from_node(&word);
+                child.remove_word_from_node(word);
 
                 if !child.end && child.children.is_empty() {
                     self.remove_child(character);
@@ -123,7 +123,7 @@ impl Trie {
         };
         for word in words.iter() {
             if !word.is_empty() {
-                instance.add(&word);
+                instance.add(word);
             }
         }
         instance
@@ -137,7 +137,7 @@ impl Trie {
         let stripped_word = word.trim();
         self.words.insert(stripped_word.raw_content().into());
         let current_cursor = self.root.borrow_mut();
-        current_cursor.add_word(&stripped_word.raw_content());
+        current_cursor.add_word(stripped_word.raw_content());
     }
 
     pub fn remove(&mut self, word: &CustomString) {

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -85,8 +85,8 @@ impl TrieNode {
         }
     }
 
-    pub fn list_prefix(&self, prefix: &CustomStringBytesSlice) -> Vec<CustomStringBytesVec> {
-        let mut result: Vec<CustomStringBytesVec> = Vec::with_capacity(100);
+    pub fn list_prefix<'d,'p>(&'d self, prefix: &'p CustomStringBytesSlice) -> Vec<&'p CustomStringBytesSlice> {
+        let mut result: Vec<&CustomStringBytesSlice> = Vec::with_capacity(100);
         let prefix_cpy = prefix;
         let mut current_index = 0;
         let mut current_node_wrap = Some(self);
@@ -97,7 +97,7 @@ impl TrieNode {
                     if child.end {
                         let substring_of_prefix =
                             prefix_cpy.slice_by_char_indice(0, current_index + 1);
-                        result.push(substring_of_prefix.to_vec());
+                        result.push(substring_of_prefix);
                     }
                     current_node_wrap = Some(child);
                 } else {
@@ -149,7 +149,7 @@ impl Trie {
         }
     }
 
-    pub fn prefix(&self, prefix: &CustomStringBytesSlice) -> Vec<Vec<u8>> {
+    pub fn prefix<'d,'p>(&'d self, prefix: &'p CustomStringBytesSlice) -> Vec<&'p CustomStringBytesSlice> {
         self.root.list_prefix(prefix)
     }
 

--- a/src/tokenizer/trie_custom.rs
+++ b/src/tokenizer/trie_custom.rs
@@ -4,7 +4,6 @@ use crate::fixed_bytes_str::four_bytes::{
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::BorrowMut;
-use std::iter::Iterator;
 /**
 This module is meant to be a direct implementation of Dict Trie in PythaiNLP.
 
@@ -197,6 +196,6 @@ impl Trie {
     }
 
     pub fn amount_of_words(&self) -> usize {
-        self.words.iter().count()
+        self.words.len()
     }
 }

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -150,9 +150,9 @@ fn test_long_text_byte_tokenizer() {
     .join("");
 
     let newmm_default_dict = NewmmCustom::new(None);
-    let result = newmm_default_dict.segment(&long_text, None, Some(true));
+    let result = newmm_default_dict.segment(&long_text, None, Some(true)).unwrap();
 
-    let safe_result = newmm_default_dict.segment(&long_text, Some(true), Some(true));
+    let safe_result = newmm_default_dict.segment(&long_text, Some(true), Some(true)).unwrap();
     assert_eq!(result.len(), 1889);
     assert_eq!(safe_result.len(), 1991);
 }


### PR DESCRIPTION
This PR has 2 major changes
1. Change hashmap and hashset from ahash to rustc_hash, which improves speed a little bit. 
2. (Incrementally) improve error handling in Newmm functions - internal_segment and other functions now return Result. Tokenizer trait is also changed.

Cargo [profile.release] configuration is experimental, I try a method from [The Performance Book](https://nnethercote.github.io/perf-book/build-configuration.html)

Need help with benchmarking.

Will also close #38