### PR TITLE
Remove `pub` out of internal_segment

### DIFF
--- a/src/tokenizer/newmm_custom.rs
+++ b/src/tokenizer/newmm_custom.rs
@@ -305,7 +305,7 @@ impl Newmm {
         Ok(result_str)
     }
 
-    pub fn internal_segment(
+    fn internal_segment(
         input: &CustomString,
         custom_dict: &Trie,
         safe: bool,


### PR DESCRIPTION
`internal_segment` is uses for segment words internally. It should access
only via `segment` or `segment_to_string` which's Tokenizer methods.