### PR TITLE
clarify python binding load_dict behavior

### DIFF
--- a/nlpo3-python/nlpo3/__init__.py
+++ b/nlpo3-python/nlpo3/__init__.py
@@ -6,17 +6,19 @@ from ._nlpo3_python_backend import (
 from typing import List
 
 
-def load_dict(file_path: str, dict_name: str):
+def load_dict(file_path: str, dict_name: str) -> tuple[str,bool]:
     """Load dictionary from a file.
 
+    *** This function does not override an existing dict name. ***
+    
     :param file_path: Absolute path to a dictionary file
     :type file_path: str
     :param dict_name: A unique dictionary name, use for reference.
-        Can be any valid utf-8 string, except "default" which is reserved.
     :type dict_name: str
+    :return tuple[human_readable_result_str, bool]
     """
-    load_result = rust_load_dict(file_path, dict_name)
-    print(load_result)
+    return rust_load_dict(file_path, dict_name)
+    
 
 
 def segment(

--- a/nlpo3-python/nlpo3/__init__.py
+++ b/nlpo3-python/nlpo3/__init__.py
@@ -6,11 +6,11 @@ from ._nlpo3_python_backend import (
 from typing import List
 
 
-def load_dict(file_path: str, dict_name: str) -> tuple[str,bool]:
+def load_dict(file_path: str, dict_name: str) -> tuple[str, bool]:
     """Load dictionary from a file.
 
     *** This function does not override an existing dict name. ***
-    
+
     :param file_path: Absolute path to a dictionary file
     :type file_path: str
     :param dict_name: A unique dictionary name, use for reference.
@@ -18,12 +18,11 @@ def load_dict(file_path: str, dict_name: str) -> tuple[str,bool]:
     :return tuple[human_readable_result_str, bool]
     """
     return rust_load_dict(file_path, dict_name)
-    
 
 
 def segment(
     text: str,
-    dict_name: str = "default",
+    dict_name: str,
     safe: bool = False,
     parallel: bool = False,
 ) -> List[str]:
@@ -34,7 +33,7 @@ def segment(
 
     :param text: Input text
     :type text: str
-    :param dict_name: Path to dictionary, defaults to "default"
+    :param dict_name: Path to dictionary
     :type dict_name: str, optional
     :param safe: Use safe mode to avoid long waiting time in
         a text with lots of ambiguous word boundaries,

--- a/nlpo3-python/src/lib.rs
+++ b/nlpo3-python/src/lib.rs
@@ -16,7 +16,7 @@ lazy_static! {
 // / --
 // /
 // / This function is newmm algorithhm.
-// / Uses only default dict.
+// 
 // / Can use multithreading, but takes a lot of memory.
 
 // / returns list of valid utf-8 bytes list
@@ -44,24 +44,24 @@ fn segment(
 ///
 /// This function loads a dictionary file and add it to dict collection
 /// Dict file must be a file of words seperate by line.
-
-/// returns a string of loading result
+/// returns a tuple of string of loading result and a boolean
+/// // / signature:    (file_path: str, in_mem_dict_name: str) -> (str,boolean)
 #[pyfunction]
-fn load_dict(file_path: &str, dict_name: &str) -> PyResult<String> {
+fn load_dict(file_path: &str, dict_name: &str) -> PyResult<(String,bool)> {
     let mut dict_col_lock = DICT_COLLECTION.lock().unwrap();
-    if let Some(_) = dict_col_lock.get(dict_name) {
-        Ok(format!(
-            "Failed: dictionary {} exists, please use another name.",
+    if dict_col_lock.get(dict_name).is_some() {
+        Ok((format!(
+            "Failed: dictionary {} already exists, please use another name.",
             dict_name
-        ))
+        ),false))
     } else {
         let newmm_dict = Newmm::new(Some(file_path));
         dict_col_lock.insert(dict_name.to_owned(), Box::new(newmm_dict));
 
-        Ok(format!(
-            "Successful: dictionary name {} from file {} has been successfully loaded",
+        Ok((format!(
+            "Successful: dictionary name {} from file {} has been successfully loaded.",
             dict_name, file_path
-        ))
+        ),true))
     }
 }
 

--- a/nlpo3-python/src/lib.rs
+++ b/nlpo3-python/src/lib.rs
@@ -9,7 +9,6 @@ use std::sync::Mutex;
 use tokenizer::tokenizer_trait::Tokenizer;
 lazy_static! {
     static ref DICT_COLLECTION:Mutex<HashMap<String,Box<Newmm>>> = Mutex::new(HashMap::new());
-    // static ref DEFAULT_DICT:Newmm = Newmm::new(None);
 }
 
 // / segment(text, dict_name, safe, parallel, /)


### PR DESCRIPTION
1. Python binding.load_dict now returns (str, bool) instead of only str.
2. Add comment to clarify load_dict behavior regarding dict name override.
3. Update load_dict wrapper in __init__.py to return the result of  binding.load_dict instead of printing it.

4. Remove misleading comment about outdated reserved "default" dict name in binding.load_dict.