### PR TITLE
Add from_word_list() for Newmm tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with Python and Node bindings. Formerly oxidized-thainlp.
 
 ## Usage
 
-### Command line interface
+### Command-line interface
 
 - [nlpo3-cli](nlpo3-cli/) <a href="https://crates.io/crates/nlpo3-cli/"><img alt="crates.io" src="https://img.shields.io/crates/v/nlpo3-cli.svg"/></a>
 
@@ -35,9 +35,10 @@ echo "ฉันกินข้าว" | nlpo3 segment
 - [Python](nlpo3-python/) <a href="https://pypi.python.org/pypi/nlpo3"><img alt="pypi" src="https://img.shields.io/pypi/v/nlpo3.svg"/></a>
 
 ```python
-from nlpo3 import segment
+from nlpo3 import load_dict, segment
 
-segment("สวัสดีครับ")
+load_dict("path/to/dict.file", "dict_name")
+segment("สวัสดีครับ", "dict_name")
 ```
 
 ### As Rust library
@@ -49,6 +50,14 @@ In `Cargo.toml`:
 [dependencies]
 # ...
 nlpo3 = "1.3.1"
+```
+
+```rust
+use nlpo3::tokenizer::newmm::NewmmTokenizer;
+use nlpo3::tokenizer::tokenizer_trait::Tokenizer;
+
+let tokenizer = NewmmTokenizer::new("path/to/dict.file");
+let tokens = tokenizer.segment("สวัสดีครับ", false, true).unwrap();
 ```
 
 ## Build

--- a/src/tokenizer/dict_reader.rs
+++ b/src/tokenizer/dict_reader.rs
@@ -12,8 +12,8 @@ pub enum DictSource {
 
 pub fn create_dict_trie(source: DictSource) -> Result<Trie, Box<dyn Error>> {
     match source {
-        DictSource::FilePath(single_source) => {
-            let file_reader = File::open(single_source.as_path());
+        DictSource::FilePath(file_path) => {
+            let file_reader = File::open(file_path.as_path());
             match file_reader {
                 Ok(file) => {
                     let mut reader = BufReader::new(file);
@@ -39,4 +39,18 @@ pub fn create_dict_trie(source: DictSource) -> Result<Trie, Box<dyn Error>> {
             Ok(Trie::new(&custom_word_list))
         }
     }
+}
+
+#[test]
+fn test_trie() {
+    let test_word_list = vec![
+        "กากบาท".to_string(),
+        "กาแฟ".to_string(),
+        "กรรม".to_string(),
+        "42".to_string(),
+        "aง|.%".to_string(),
+    ];
+    let trie = create_dict_trie(DictSource::WordList(test_word_list)).unwrap();
+    assert_eq!(trie.contain(&CustomString::new("กาแฟ")), true);
+    assert_eq!(trie.amount_of_words(), 5);
 }

--- a/src/tokenizer/newmm.rs
+++ b/src/tokenizer/newmm.rs
@@ -114,7 +114,7 @@ impl NewmmTokenizer {
         }
     }
 
-    pub fn new_from_word_list(word_list: Vec<String>) -> Self {
+    pub fn from_word_list(word_list: Vec<String>) -> Self {
         NewmmTokenizer {
             dict: Box::from(
                 create_dict_trie(DictSource::WordList(word_list)).unwrap(),

--- a/src/tokenizer/newmm.rs
+++ b/src/tokenizer/newmm.rs
@@ -114,6 +114,14 @@ impl NewmmTokenizer {
         }
     }
 
+    pub fn new_from_word_list(word_list: Vec<String>) -> Self {
+        NewmmTokenizer {
+            dict: Box::from(
+                create_dict_trie(DictSource::WordList(word_list)).unwrap(),
+            ),
+        }
+    }
+
     fn bfs_paths_graph(
         graph: &HashMap<CharacterIndex, Vec<CharacterIndex>>,
         start: CharacterIndex,

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -7,7 +7,7 @@ const SECOND_TEXT: &str =
 const DEFAULT_DICT_PATH: &str = "/words_th.txt"; // relative to cargo
 
 #[test]
-fn test_new_from_word_list() {
+fn test_from_word_list() {
     let test_word_list = vec![
         "กากบาท".to_string(),
         "กาแฟ".to_string(),
@@ -15,7 +15,7 @@ fn test_new_from_word_list() {
         "42".to_string(),
         "aง|.%".to_string(),
     ];
-    let _tokenizer = NewmmTokenizer::new_from_word_list(test_word_list);
+    let _tokenizer = NewmmTokenizer::from_word_list(test_word_list);
 }
 
 #[test]

--- a/tests/test_tokenizer.rs
+++ b/tests/test_tokenizer.rs
@@ -7,6 +7,18 @@ const SECOND_TEXT: &str =
 const DEFAULT_DICT_PATH: &str = "/words_th.txt"; // relative to cargo
 
 #[test]
+fn test_new_from_word_list() {
+    let test_word_list = vec![
+        "กากบาท".to_string(),
+        "กาแฟ".to_string(),
+        "กรรม".to_string(),
+        "42".to_string(),
+        "aง|.%".to_string(),
+    ];
+    let _tokenizer = NewmmTokenizer::new_from_word_list(test_word_list);
+}
+
+#[test]
 fn test_long_text_byte_tokenizer() {
     let mut relative_test_dict_path = env!("CARGO_MANIFEST_DIR").to_string();
     relative_test_dict_path.push_str(DEFAULT_DICT_PATH);


### PR DESCRIPTION
Trying to make it is possible to create a NewmmTokenizer from Vec<String>.

Very new to Rust. Please check if this is the way people doing a proper Rust.
- Maybe it's less computational if we can just use a fixed array of &str?
- Does it possible to merge this with the existing `new()` ?

The use case is the user may already have a word list (or a trie) that they would like to fine tune
(removing/adding words) and create different tokenizers from this evolving list of words.
For easy processing, the list of word is in the memory not in the file.
