### PR TITLE
Update match non-Thai tokens

### DIFF
--- a/src/tokenizer/newmm.rs
+++ b/src/tokenizer/newmm.rs
@@ -42,7 +42,7 @@ const TEXT_SCAN_END: usize = TEXT_SCAN_POINT + TEXT_SCAN_RIGHT;
 
 type CharacterIndex = usize;
 
-const NON_THAI_READABLE_PATTERN: &[&str; 5] = &[
+const NON_THAI_READABLE_PATTERN: &[&str; 6] = &[
     r"(?x)^[-a-zA-Z]+",
     r"(?x)^[0-9]+([,\.][0-9]+)*",
     r"(?x)^[๐-๙]+([,\.][๐-๙]+)*",


### PR DESCRIPTION
From https://github.com/PyThaiNLP/pythainlp/pull/856, newmm has updated the rule. I added the regex to up-to-date nlpo3. 