### PR TITLE
Allow unreachable code during test

### DIFF
--- a/.github/workflows/test-main-lib.yml
+++ b/.github/workflows/test-main-lib.yml
@@ -38,4 +38,6 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Test
+      env:
+        RUSTFLAGS: "-A unreachable_code"
       run: cargo test


### PR DESCRIPTION
Set `RUSTFLAGS` = `-A unreachable_code` environment for `cargo test` to suppressed "unreachable code" errors/warnings
- they are warnings in my local environment
  > stable-x86_64-apple-darwin (default)
  > rustc 1.82.0 (f6e511eec 2024-10-15)
- but the same warnings are converted to errors in the CI and made the test failed

I'm not sure if this is a good practice.

Will the code still not able to build elsewhere?
