### PR TITLE
Fix build python wheels

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -83,12 +83,6 @@ jobs:
         - os: windows-latest
           bitness: 32
           platform_id: win32
-        - os: macos-latest
-          pip-path: ~/Library/Caches/pip
-        - os: ubuntu-latest
-          pip-path: ~/.cache/pip
-        - os: windows-latest
-          pip-path: ~\AppData\Local\pip\Cache
         exclude:
         - os: macos-latest
           bitness: 32

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -11,6 +11,7 @@ on:
     - 'nlpo3-python/**'
     - '!nlpo3-python/**.md'
     - '!nlpo3-python/notebooks/**'
+    - '.github/workflows/build-python-wheels.yml'
   pull_request:
     branches:
     - main
@@ -18,6 +19,7 @@ on:
     - 'nlpo3-python/**'
     - '!nlpo3-python/**.md'
     - '!nlpo3-python/notebooks/**'
+    - '.github/workflows/build-python-wheels.yml'
   release:
     types: [published]
   # Manual run

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -53,6 +53,7 @@ jobs:
     - id: check_build_trigger
       name: Check build trigger
       run: bash build_tools/github/check_build_trigger.sh
+      # To trigger the build steps, add "[cd build]" to commit message
 
   build_wheels:
     name: Build Python wheel for ${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
@@ -184,9 +185,9 @@ jobs:
     name: Publish Python package to PyPI
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist, build_wheels_macos_on_self_hosted]
-    # upload to PyPI on every tag starting with 'v'
+    # Upload to PyPI on every tag starting with 'v'
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # Alternatively, to publish when a GitHub Release is created, use the following rule:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - name: Retrieve artifacts

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -6,31 +6,34 @@ name: Build Python wheels
 on:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'nlpo3-python/**'
+    - 'nlpo3-python/**'
+    - '!nlpo3-python/**.md'
+    - '!nlpo3-python/notebooks/**'
   pull_request:
     branches:
-      - main
+    - main
     paths:
-      - 'nlpo3-python/**'
+    - 'nlpo3-python/**'
+    - '!nlpo3-python/**.md'
+    - '!nlpo3-python/notebooks/**'
   release:
     types: [published]
   # Manual run
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   echo_github_env:
     name: Echo GitHub environment variables
     runs-on: ubuntu-latest
-
     steps:
-      - run: |
-          echo "github.event.action   : ${{ github.event.action }}"
-          echo "github.event_name     : ${{ github.event_name }}"
-          echo "github.ref            : ${{ github.ref }}"
-          echo "github.event.ref      : ${{ github.event.ref }}"
-          echo "github.event.ref_type : ${{ github.event.ref_type }}"
+    - run: |
+        echo "github.event.action   : ${{ github.event.action }}"
+        echo "github.event_name     : ${{ github.event_name }}"
+        echo "github.ref            : ${{ github.ref }}"
+        echo "github.event.ref      : ${{ github.event.ref }}"
+        echo "github.event.ref_type : ${{ github.event.ref_type }}"
 
   # Check whether to build the wheels and the source tarball
   check_build_trigger:
@@ -39,223 +42,166 @@ jobs:
     if: github.repository == 'pythainlp/nlpo3'
     outputs:
       build: ${{ steps.check_build_trigger.outputs.build }}
-
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - id: check_build_trigger
-        name: Check build trigger
-        run: bash build_tools/github/check_build_trigger.sh
+    - name: Checkout source code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - id: check_build_trigger
+      name: Check build trigger
+      run: bash build_tools/github/check_build_trigger.sh
 
   build_wheels:
     name: Build Python wheel for ${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
-
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [cp36, cp37, cp38, cp39, cp310, cp311, cp312]  # pp37
+        python: [ccp39, cp310, cp311, cp312, cp318]
         bitness: [32, 64]
         manylinux_image: [manylinux2014]
         include:
-          - os: macos-latest
-            bitness: 64
-            platform_id: macosx_x86_64
-          - os: ubuntu-latest
-            bitness: 64
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
-            bitness: 32
-            platform_id: manylinux_i686
-          - os: windows-latest
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            bitness: 32
-            platform_id: win32
-          - os: macos-latest
-            pip-path: ~/Library/Caches/pip
-          - os: ubuntu-latest
-            pip-path: ~/.cache/pip
-          - os: windows-latest
-            pip-path: ~\AppData\Local\pip\Cache
+        - os: macos-latest
+          bitness: 64
+          platform_id: macosx_x86_64
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: manylinux_x86_64
+        - os: ubuntu-latest
+          bitness: 32
+          platform_id: manylinux_i686
+        - os: windows-latest
+          bitness: 64
+          platform_id: win_amd64
+        - os: windows-latest
+          bitness: 32
+          platform_id: win32
+        - os: macos-latest
+          pip-path: ~/Library/Caches/pip
+        - os: ubuntu-latest
+          pip-path: ~/.cache/pip
+        - os: windows-latest
+          pip-path: ~\AppData\Local\pip\Cache
         exclude:
-          - os: macos-latest
-            bitness: 32
+        - os: macos-latest
+          bitness: 32
 #          - python: pp37
 #            bitness: 32
-
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-          
-      - name: Setup Rust toolchain - non-win32
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          toolchain: stable
-        if: ${{ !startsWith(matrix.os, 'windows') || matrix.bitness != '32' }}
-
-      - name: Setup Rust toolchain - win32
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          toolchain: stable
-          target: i686-pc-windows-msvc
-        if: startsWith(matrix.os, 'windows') && matrix.bitness == '32'
-
-      - name: Setup Rust dependencies
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          toolchain: stable
-        if: ${{ !startsWith(matrix.os, 'windows') && matrix.bitness != '32' }}
-
-      - name: Cache Rust files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ matrix.os }}-${{ matrix.bitness }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.bitness }}-cargo-
-
-      - name: Setup Python
-        uses: actions/setup-python@v3
-#        with:
-#          python-version: "3.8"
-
-      - name: Cache Python files
-        uses: actions/cache@v2
-        with:
-          path: ${{ matrix.pip-path }}
-          key: ${{ matrix.os }}-${{ matrix.bitness }}-pip-${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.bitness }}-pip-${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}-
-      - name: Update pip
-        run: |
-          python -m pip install -U pip
-      - name: Build Python wheels
-        uses: pypa/cibuildwheel@v2.11.2
-        with:
-          package-dir: nlpo3-python
-          output-dir: wheelhouse
-        env:
-          CIBW_BUILD_VERBOSITY: 1
-          # See build selector name at:
-          # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform_id }}
-          CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.13
-                                  PATH="$HOME/.cargo/bin:$PATH"
-                                  CC=/usr/bin/clang
-                                  CXX=/usr/bin/clang++
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_MANYLINUX_PYPY_I686_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_BEFORE_BUILD_LINUX: >
-            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y
-          CIBW_BEFORE_BUILD_WINDOWS: 'rustup default stable'
-
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
+    - name: Checkout source code
+      uses: actions/checkout@v4
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        cache: "pip"
+    - name: Update pip
+      run: |
+        python -m pip install --upgrade pip
+    - name: Build Python wheels
+      uses: pypa/cibuildwheel@v2.21.3
+      with:
+        package-dir: nlpo3-python
+        output-dir: wheelhouse
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+        # See build selector name at:
+        # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform_id }}
+        CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.13
+                                PATH="$HOME/.cargo/bin:$PATH"
+                                CC=/usr/bin/clang
+                                CXX=/usr/bin/clang++
+        CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+        CIBW_MANYLINUX_PYPY_I686_IMAGE: ${{ matrix.manylinux_image }}
+        CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+        CIBW_BEFORE_BUILD_LINUX: >
+          curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y
+        CIBW_BEFORE_BUILD_WINDOWS: 'rustup default stable'
+    - name: Store artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build Python source distribution
     runs-on: ubuntu-latest
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
-
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
+    - name: Checkout source code
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        cache: "pip"
+    - name: Build source distribution
+      run: |
+        cd nlpo3-python
+        bash ../build_tools/github/build_source.sh
+    - name: Store artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: nlpo3-python/dist/*.tar.gz
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-
-      - name: Build source distribution
-        run: |
-          cd nlpo3-python
-          bash ../build_tools/github/build_source.sh
-
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          path: nlpo3-python/dist/*.tar.gz
   build_wheels_macos:
     name: Build wheels on M1
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3
-      #- name: Setup Rust dependencies
-      #  uses: ATiltedTree/setup-rust@v1
-      #  with:
-      #    rust-version: 1.65.0
-      - name: Test
-        run: cargo test
-
-      - name: Build wheels - py38
-        run: |
-            source ~/miniconda3/etc/profile.d/conda.sh
-            conda init zsh
-            cd nlpo3-python
-            conda activate python38
-            python -V
-            python -m pip install maturin
-            python -m pip list
-            python -m pip wheel . -w build
-            conda deactivate
-            cd ..
-        shell: zsh {0}
-      - name: Build wheels - py39
-        run: |
-            source ~/miniconda3/etc/profile.d/conda.sh
-            conda init zsh
-            cd nlpo3-python
-            conda activate python39
-            python -V
-            python -m pip install maturin
-            python -m pip list
-            python -m pip wheel . -w build
-            conda deactivate
-            cd ..
-        shell: zsh {0}
-      - name: Build wheels - py310
-        run: |
-            source ~/miniconda3/etc/profile.d/conda.sh
-            conda init zsh
-            cd nlpo3-python
-            conda activate python310
-            python -V
-            python -m pip install maturin
-            python -m pip list
-            python -m pip wheel . -w build
-            conda deactivate
-            cd ..
-        shell: zsh {0}
-      - name: Store artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          path: ./nlpo3-python/build/*.whl
+    - name: Checkout source code
+      uses: actions/checkout@v4
+    - name: Test
+      run: cargo test
+    - name: Build wheels - py39
+      run: |
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda init zsh
+          cd nlpo3-python
+          conda activate python39
+          python -V
+          python -m pip install maturin
+          python -m pip list
+          python -m pip wheel . -w build
+          conda deactivate
+          cd ..
+      shell: zsh {0}
+    - name: Build wheels - py310
+      run: |
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda init zsh
+          cd nlpo3-python
+          conda activate python310
+          python -V
+          python -m pip install maturin
+          python -m pip list
+          python -m pip wheel . -w build
+          conda deactivate
+          cd ..
+      shell: zsh {0}
+    - name: Build wheels - py311
+      run: |
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda init zsh
+          cd nlpo3-python
+          conda activate python311
+          python -V
+          python -m pip install maturin
+          python -m pip list
+          python -m pip wheel . -w build
+          conda deactivate
+          cd ..
+      shell: zsh {0}
+    - name: Store artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: ./nlpo3-python/build/*.whl
 
   publish_pypi:
     name: Publish Python package to PyPI
@@ -265,17 +211,15 @@ jobs:
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     if: github.event_name == 'release' && github.event.action == 'published'
-
     steps:
-      - name: Retrieve artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Retrieve artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: artifact
+        path: dist
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@v1.12.2
+      with:
+        skip-existing: true
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -63,6 +63,8 @@ jobs:
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
+      # For build identier, see:
+      # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python: [cp39, cp310, cp311, cp312, cp313, pp39, pp310]

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -150,7 +150,9 @@ jobs:
       with:
         path: nlpo3-python/dist/*.tar.gz
 
-  build_wheels_macos:
+  # May consider remove this job if no longer needed
+  # GitHub runners now have arm64 architecture
+  build_wheels_macos_on_self_hosted:
     name: Build wheels on M1
     runs-on: self-hosted
     strategy:
@@ -183,7 +185,7 @@ jobs:
   publish_pypi:
     name: Publish Python package to PyPI
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist, build_wheels_macos]
+    needs: [build_wheels, build_sdist, build_wheels_macos_on_self_hosted]
     # upload to PyPI on every tag starting with 'v'
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -56,7 +56,7 @@ jobs:
       # To trigger the build steps, add "[cd build]" to commit message
 
   build_wheels:
-    name: Build Python wheel for ${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
+    name: Build Python wheel for ${{ matrix.python }}-${{ matrix.platform_id }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -65,19 +65,36 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [cp39, cp310, cp311, cp312, cp313]
+        python: [cp39, cp310, cp311, cp312, cp313, pp39, pp310]
         bitness: [32, 64]
-        manylinux_image: [manylinux2014]
         include:
         - os: macos-latest
           bitness: 64
           platform_id: macosx_x86_64
+        - os: macos-latest
+          bitness: 64
+          platform_id: macosx_arm64
+        - os: macos-latest
+          bitness: 64
+          platform_id: macosx_universal2
         - os: ubuntu-latest
           bitness: 64
           platform_id: manylinux_x86_64
         - os: ubuntu-latest
           bitness: 32
           platform_id: manylinux_i686
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: musllinux_x86_64
+        - os: ubuntu-latest
+          bitness: 32
+          platform_id: musllinux_i686
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: manylinux_aarch64
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: musllinux_aarch64
         - os: windows-latest
           bitness: 64
           platform_id: win_amd64
@@ -87,6 +104,18 @@ jobs:
         exclude:
         - os: macos-latest
           bitness: 32
+        - python: pp39
+          platform_id: macosx_universal2
+        - python: pp310
+          platform_id: macosx_universal2
+        - python: pp39
+          platform_id: musllinux_x86_64
+        - python: pp310
+          platform_id: musllinux_x86_64
+        - python: pp39
+          platform_id: win32
+        - python: pp310
+          platform_id: win32
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -110,17 +139,10 @@ jobs:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
         CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform_id }}
         CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.13
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
                                 PATH="$HOME/.cargo/bin:$PATH"
                                 CC=/usr/bin/clang
                                 CXX=/usr/bin/clang++
-        CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
-        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-        CIBW_MANYLINUX_PYPY_I686_IMAGE: ${{ matrix.manylinux_image }}
-        CIBW_MANYLINUX_PYPY_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-        CIBW_BEFORE_BUILD_LINUX: >
-          curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=minimal -y
-        CIBW_BEFORE_BUILD_WINDOWS: 'rustup default stable'
     - name: Store artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -147,44 +169,10 @@ jobs:
       with:
         path: nlpo3-python/dist/*.tar.gz
 
-  # May consider remove this job if no longer needed
-  # GitHub runners now have arm64 architecture
-  build_wheels_macos_on_self_hosted:
-    name: Build wheels on M1
-    runs-on: self-hosted
-    needs: check_build_trigger
-    if: needs.check_build_trigger.outputs.build
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v4
-    - name: Test
-      run: cargo test
-    - name: Build wheels
-      run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda init zsh
-        cd nlpo3-python
-        conda create --name python${{ matrix.python-version }} python=${{ matrix.python-version }} -y
-        conda activate python${{ matrix.python-version }}
-        python -V
-        python -m pip install maturin
-        python -m pip list
-        python -m pip wheel . -w build
-        conda deactivate
-        cd ..
-      shell: zsh {0}
-    - name: Store artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        path: ./nlpo3-python/build/*.whl
-
   publish_pypi:
     name: Publish Python package to PyPI
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist, build_wheels_macos_on_self_hosted]
+    needs: [build_wheels, build_sdist]
     # Upload to PyPI on every tag starting with 'v'
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -151,6 +151,8 @@ jobs:
   build_wheels_macos_on_self_hosted:
     name: Build wheels on M1
     runs-on: self-hosted
+    needs: check_build_trigger
+    if: needs.check_build_trigger.outputs.build
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -39,6 +39,7 @@ jobs:
   check_build_trigger:
     name: Check build trigger
     runs-on: ubuntu-latest
+    # Not for forks
     if: github.repository == 'pythainlp/nlpo3'
     outputs:
       build: ${{ steps.check_build_trigger.outputs.build }}
@@ -61,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [ccp39, cp310, cp311, cp312, cp318]
+        python: [cp39, cp310, cp311, cp312, cp313]
         bitness: [32, 64]
         manylinux_image: [manylinux2014]
         include:
@@ -89,8 +90,6 @@ jobs:
         exclude:
         - os: macos-latest
           bitness: 32
-#          - python: pp37
-#            bitness: 32
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -154,49 +153,27 @@ jobs:
   build_wheels_macos:
     name: Build wheels on M1
     runs-on: self-hosted
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
     - name: Test
       run: cargo test
-    - name: Build wheels - py39
+    - name: Build wheels
       run: |
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda init zsh
-          cd nlpo3-python
-          conda activate python39
-          python -V
-          python -m pip install maturin
-          python -m pip list
-          python -m pip wheel . -w build
-          conda deactivate
-          cd ..
-      shell: zsh {0}
-    - name: Build wheels - py310
-      run: |
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda init zsh
-          cd nlpo3-python
-          conda activate python310
-          python -V
-          python -m pip install maturin
-          python -m pip list
-          python -m pip wheel . -w build
-          conda deactivate
-          cd ..
-      shell: zsh {0}
-    - name: Build wheels - py311
-      run: |
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda init zsh
-          cd nlpo3-python
-          conda activate python311
-          python -V
-          python -m pip install maturin
-          python -m pip list
-          python -m pip wheel . -w build
-          conda deactivate
-          cd ..
+        source ~/miniconda3/etc/profile.d/conda.sh
+        conda init zsh
+        cd nlpo3-python
+        conda create --name python${{ matrix.python-version }} python=${{ matrix.python-version }} -y
+        conda activate python${{ matrix.python-version }}
+        python -V
+        python -m pip install maturin
+        python -m pip list
+        python -m pip wheel . -w build
+        conda deactivate
+        cd ..
       shell: zsh {0}
     - name: Store artifacts
       uses: actions/upload-artifact@v4

--- a/nlpo3-python/README.md
+++ b/nlpo3-python/README.md
@@ -86,11 +86,11 @@ segment("สวัสดีครับ", dict_name="dict_name", safe=True)
 ### Requirements
 
 - [Rust 2018 Edition](https://www.rust-lang.org/tools/install)
-- Python 3.6 or newer
+- Python 3.9 or newer
 - Python Development Headers
   - Ubuntu: `sudo apt-get install python3-dev`
   - macOS: No action needed
-- [PyO3](https://github.com/PyO3/pyo3) - already included in Cargo.toml
+- [PyO3](https://github.com/PyO3/pyo3) - already included in `Cargo.toml`
 - [setuptools-rust](https://github.com/PyO3/setuptools-rust)
 
 ### Steps

--- a/nlpo3-python/pyproject.toml
+++ b/nlpo3-python/pyproject.toml
@@ -7,7 +7,7 @@ name = "nlpo3"
 version = "1.3.1-dev"
 description = "Python binding for nlpO3 Thai language processing library in Rust"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 keywords = ["thai", "tokenizer", "nlp", "word-segmentation", "pythainlp"]
 authors = [
@@ -38,7 +38,7 @@ homepage = "https://github.com/PyThaiNLP/nlpo3/"
 repository = "https://github.com/PyThaiNLP/nlpo3/"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
To fix #64

Looks like we have issue with `ciwheelbuild`

- Use actions-rust-lang/setup-rust-toolchain for Rust toolchain setup
- Remove manual cache management, let setup-rust-toolchain and setup-python handle that
- Update GitHub Actions dependencies
