### PR TITLE
[nlpo3-python] Add builds for more platforms

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -173,7 +173,7 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD_VERBOSITY: 1
-        # See build selector name at:
+        # See CIBW_ARCHS and other build selectors at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
         CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
         CIBW_ENVIRONMENT_MACOS: |

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -82,18 +82,18 @@ jobs:
         - os: ubuntu-latest
           bitness: 32
           platform_id: manylinux_i686
-        # - os: ubuntu-latest
-        #   bitness: 64
-        #   platform_id: musllinux_x86_64
-        # - os: ubuntu-latest
-        #   bitness: 32
-        #   platform_id: musllinux_i686
-        # - os: ubuntu-latest
-        #   bitness: 64
-        #   platform_id: manylinux_aarch64
-        # - os: ubuntu-latest
-        #   bitness: 64
-        #   platform_id: musllinux_aarch64
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: musllinux_x86_64
+        - os: ubuntu-latest
+          bitness: 32
+          platform_id: musllinux_i686
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: manylinux_aarch64
+        - os: ubuntu-latest
+          bitness: 64
+          platform_id: musllinux_aarch64
         - os: windows-latest
           bitness: 64
           platform_id: win_amd64

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -115,7 +115,7 @@ jobs:
         # It is needed to install Rust for Linux,
         # because cibuildwheel on Linux runs inside a container
         # and the container does not have Rust.
-        CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
+        CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
     - name: Store artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -161,6 +161,11 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       # For Linux, Rust will be installed inside a cibuildwheel container later
 
+    - name: Setup rustup target
+      if: startsWith(matrix.os, 'macos-')
+      run: rustup target add x86_64-apple-darwin
+      # For cross-compile x86 on GitHub arm64 runner
+
     - name: Build Python wheels
       uses: pypa/cibuildwheel@v2.21.3
       with:

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -63,89 +63,13 @@ jobs:
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
-      # For build identier, see:
-      # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
       matrix:
-        # See more build combinations at "Make CIBW_BUILD list" steps below
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ["3.13"]
-        # python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9", "pypy3.8", "pypy3.7"]
-        # bitness: [64, 32]
-        # include:
-        # - os: windows-latest
-        #   bitness: 64
-        #   platform_id: win_amd64
-        # - os: windows-latest
-        #   bitness: 32
-        #   platform_id: win32
-        # exclude:
-        # - os: macos-latest
-        #   bitness: 32
-        # - os: macos-latest
-        #   python-version: "3.7"
-        # - os: macos-latest
-        #   python-version: "pypy3.7"
     env:
-      CP_VER: ""
-      CIBW_BUILD: ""  # let cibuildwheel cover the supported platforms
+      CIBW_BUILD: ""  # blank, let cibuildwheel build all supported platforms
 
     steps:
-    # cibuildwheel needs a specific Python implementation ID
-    - name: Make Python implementation ID (non-Windows)
-      id: convert-version-id
-      if: startsWith(matrix.os, 'windows-') == false
-      run: |
-        PYTHON_VERSION=${{ matrix.python-version }}
-        if [[ "$PYTHON_VERSION" == pypy* ]]; then
-          CP_VER="pp${PYTHON_VERSION:4}"
-          CP_VER="${CP_VER//./}"
-        else
-          CP_VER="cp${PYTHON_VERSION//./}"
-        fi
-        echo "Python version: $CP_VER"
-        echo "CP_VER=$CP_VER" >> $GITHUB_ENV
-
-    - name: Make Python implementation ID (Windows)
-      id: convert-version-id-win
-      if: startsWith(matrix.os, 'windows-')
-      shell: powershell
-      run: |
-        $PYTHON_VERSION = "${{ matrix.python-version }}"
-        if ($PYTHON_VERSION -like "pypy*") {
-          $CP_VER = "pp" + $PYTHON_VERSION.Substring(4).Replace(".", "")
-        } else {
-          $CP_VER = "cp" + $PYTHON_VERSION.Replace(".", "")
-        }
-        echo "Python version: $CP_VER"
-        echo "CP_VER=$CP_VER" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-    # - name: Make CIBW_BUILD list (macOS)
-    #   if: startsWith(matrix.os, 'macos-')
-    #   run: echo "CIBW_BUILD=${{ env.CP_VER }}-macosx*" >> $GITHUB_ENV
-
-    # - name: Make CIBW_BUILD list (Linux 64-bit)
-    #   if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 64
-    #   run: |
-    #     CP_VER=${{ env.CP_VER }}
-    #     CIBW_BUILD="$CP_VER-manylinux_x86_64"
-    #     if [[ "$CP_VER" != pp* ]]; then
-    #       CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_x86_64"
-    #     fi
-    #     echo "CIBW_BUILD: $CIBW_BUILD"
-    #     echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
-      
-    # - name: Make CIBW_BUILD list (Linux 32-bit)
-    #   if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 32
-    #   run: |
-    #     CP_VER=${{ env.CP_VER }}
-    #     CIBW_BUILD="$CP_VER-manylinux_i686"
-    #     echo "CIBW_BUILD: $CIBW_BUILD"
-    #     echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
-
-    # - name: Make CIBW_BUILD list (Windows)
-    #   if: startsWith(matrix.os, 'windows-')
-    #   run: CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
-
     - name: Checkout source code
       uses: actions/checkout@v4
 
@@ -174,8 +98,9 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD_VERBOSITY: 1
-        # See CIBW_ARCHS and other build selectors at:
+        # See CIBW_BUILD, CIBW_SKIP, CIBW_ARCHS and other build selectors at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        CIBW_SKIP: "cp37-musllinux_i686"
         CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_ENVIRONMENT_MACOS: |
           MACOSX_DEPLOYMENT_TARGET=10.9

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -1,7 +1,7 @@
-# Build wheels for many platforms
+# Build wheels for many platforms, use cibuildwheel
 # see: https://github.com/pypa/cibuildwheel
 
-name: Build Python wheels
+name: Build wheels
 
 on:
   push:
@@ -27,7 +27,7 @@ on:
 
 jobs:
   echo_github_env:
-    name: Echo GitHub environment variables
+    name: Echo env variables
     runs-on: ubuntu-latest
     steps:
     - run: |
@@ -56,7 +56,7 @@ jobs:
       # To trigger the build steps, add "[cd build]" to commit message
 
   build_wheels:
-    name: Build ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -100,7 +100,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         # See CIBW_BUILD, CIBW_SKIP, CIBW_ARCHS and other build selectors at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        CIBW_SKIP: "cp37-musllinux_i686"
+        CIBW_SKIP: "*-musllinux_i686"
         CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_ENVIRONMENT_MACOS: |
           MACOSX_DEPLOYMENT_TARGET=10.9
@@ -115,7 +115,7 @@ jobs:
         # It is needed to install Rust for Linux,
         # because cibuildwheel on Linux runs inside a container
         # and the container does not have Rust.
-        CIBW_ARCHS_WINDOWS: "AMD64 x86"
+        CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
 
     - name: Store artifacts
       uses: actions/upload-artifact@v3
@@ -123,7 +123,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   build_sdist:
-    name: Build Python source distribution
+    name: Build source distribution
     runs-on: ubuntu-latest
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -145,13 +145,13 @@ jobs:
         path: nlpo3-python/dist/*.tar.gz
 
   publish_pypi:
-    name: Publish Python package to PyPI
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist]
-    # Upload to PyPI on every tag starting with 'v'
-    #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
-    # Alternatively, to publish when a GitHub Release is created, use the following rule:
+    # Publish when a GitHub Release is created:
     if: github.event_name == 'release' && github.event.action == 'published'
+    # Alternatively, upload to PyPI on every tag starting with 'v':
+    #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     steps:
     - name: Retrieve artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -56,7 +56,7 @@ jobs:
       # To trigger the build steps, add "[cd build]" to commit message
 
   build_wheels:
-    name: Build ${{ matrix.python-version }}-${{ matrix.platform_id }}
+    name: Build ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.bitness }}-bit
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -66,8 +66,9 @@ jobs:
       # For build identier, see:
       # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
       matrix:
+        # See more build combinations at "Make CIBW_BUILD list" steps below
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9", "pypy3.8", "pypy3.7"]
         bitness: [64, 32]
         include:
         - os: macos-latest
@@ -76,24 +77,6 @@ jobs:
         - os: macos-latest
           bitness: 64
           platform_id: macosx_arm64
-        - os: ubuntu-latest
-          bitness: 64
-          platform_id: manylinux_x86_64
-        - os: ubuntu-latest
-          bitness: 32
-          platform_id: manylinux_i686
-        - os: ubuntu-latest
-          bitness: 64
-          platform_id: musllinux_x86_64
-        - os: ubuntu-latest
-          bitness: 32
-          platform_id: musllinux_i686
-        - os: ubuntu-latest
-          bitness: 64
-          platform_id: manylinux_aarch64
-        - os: ubuntu-latest
-          bitness: 64
-          platform_id: musllinux_aarch64
         - os: windows-latest
           bitness: 64
           platform_id: win_amd64
@@ -105,15 +88,17 @@ jobs:
           bitness: 32
         - os: macos-latest
           python-version: "3.7"
-        - python-version: "pypy3.10"
-          bitness: 32
-        - python-version: "pypy3.9"
-          bitness: 32
+        # - python-version: "pypy3.10"
+        #   bitness: 32
+        # - python-version: "pypy3.9"
+        #   bitness: 32
     env:
       CP_VER: ""
+      CIBW_BUILD: ""
+
     steps:
     # cibuildwheel needs a specific Python implementation ID
-    - name: Make Python implementation ID
+    - name: Make Python implementation ID (non-Windows)
       id: convert-version-id
       if: startsWith(matrix.os, 'windows-') == false
       run: |
@@ -139,19 +124,49 @@ jobs:
         }
         echo "Python version: $CP_VER"
         echo "CP_VER=$CP_VER" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Make CIBW_BUILD list (non-Linux)
+      if: startsWith(matrix.os, 'ubuntu-') == false
+      run: echo "CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
+
+    - name: Make CIBW_BUILD list (Linux 64-bit)
+      if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 64
+      run: |
+        CP_VER=${{ env.CP_VER }}
+        CIBW_BUILD="$CP_VER-manylinux_x86_64 $CP_VER-manylinux_aarch64"
+        if [[ "$CP_VER" != pp* ]]; then
+          CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_x86_64 $CP_VER-musllinux_aarch64"
+        fi
+        echo "CIBW_BUILD: $CIBW_BUILD"
+        echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
+      
+    - name: Make CIBW_BUILD list (Linux 32-bit)
+      if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 32
+      run: |
+        CP_VER=${{ env.CP_VER }}
+        CIBW_BUILD="$CP_VER-manylinux_i686"
+        if [[ "$CP_VER" != pp* ]]; then
+          CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_i686"
+        fi
+        echo "CIBW_BUILD: $CIBW_BUILD"
+        echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
+
     - name: Checkout source code
       uses: actions/checkout@v4
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade pip
+
     - name: Setup Rust toolchain
       if: startsWith(matrix.os, 'ubuntu-') == false
       uses: actions-rust-lang/setup-rust-toolchain@v1
       # For Linux, Rust will be installed inside a cibuildwheel container later
-    - name: Install Python dependencies
-      run: python -m pip install --upgrade pip
+
     - name: Build Python wheels
       uses: pypa/cibuildwheel@v2.21.3
       with:
@@ -161,7 +176,6 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         # See build selector name at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        CIBW_BUILD: ${{ env.CP_VER }}-${{ matrix.platform_id }}
         CIBW_ENVIRONMENT_MACOS: |
           MACOSX_DEPLOYMENT_TARGET=10.9
           PATH="$HOME/.cargo/bin:$PATH"
@@ -174,6 +188,7 @@ jobs:
         # It is needed to install Rust for Linux,
         # because cibuildwheel on Linux runs inside a container
         # and the container does not have Rust.
+
     - name: Store artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -56,7 +56,7 @@ jobs:
       # To trigger the build steps, add "[cd build]" to commit message
 
   build_wheels:
-    name: Build ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.bitness }}-bit
+    name: Build ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -68,25 +68,26 @@ jobs:
       matrix:
         # See more build combinations at "Make CIBW_BUILD list" steps below
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9", "pypy3.8", "pypy3.7"]
-        bitness: [64, 32]
-        include:
-        - os: windows-latest
-          bitness: 64
-          platform_id: win_amd64
-        - os: windows-latest
-          bitness: 32
-          platform_id: win32
-        exclude:
-        - os: macos-latest
-          bitness: 32
-        - os: macos-latest
-          python-version: "3.7"
-        - os: macos-latest
-          python-version: "pypy3.7"
+        python-version: ["3.13"]
+        # python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9", "pypy3.8", "pypy3.7"]
+        # bitness: [64, 32]
+        # include:
+        # - os: windows-latest
+        #   bitness: 64
+        #   platform_id: win_amd64
+        # - os: windows-latest
+        #   bitness: 32
+        #   platform_id: win32
+        # exclude:
+        # - os: macos-latest
+        #   bitness: 32
+        # - os: macos-latest
+        #   python-version: "3.7"
+        # - os: macos-latest
+        #   python-version: "pypy3.7"
     env:
       CP_VER: ""
-      CIBW_BUILD: ""
+      CIBW_BUILD: ""  # let cibuildwheel cover the supported platforms
 
     steps:
     # cibuildwheel needs a specific Python implementation ID
@@ -118,32 +119,32 @@ jobs:
         echo "Python version: $CP_VER"
         echo "CP_VER=$CP_VER" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-    - name: Make CIBW_BUILD list (macOS)
-      if: startsWith(matrix.os, 'macos-')
-      run: echo "CIBW_BUILD=${{ env.CP_VER }}-macosx*" >> $GITHUB_ENV
+    # - name: Make CIBW_BUILD list (macOS)
+    #   if: startsWith(matrix.os, 'macos-')
+    #   run: echo "CIBW_BUILD=${{ env.CP_VER }}-macosx*" >> $GITHUB_ENV
 
-    - name: Make CIBW_BUILD list (Linux 64-bit)
-      if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 64
-      run: |
-        CP_VER=${{ env.CP_VER }}
-        CIBW_BUILD="$CP_VER-manylinux_x86_64 $CP_VER-manylinux_aarch64"
-        if [[ "$CP_VER" != pp* ]]; then
-          CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_x86_64 $CP_VER-musllinux_aarch64"
-        fi
-        echo "CIBW_BUILD: $CIBW_BUILD"
-        echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
+    # - name: Make CIBW_BUILD list (Linux 64-bit)
+    #   if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 64
+    #   run: |
+    #     CP_VER=${{ env.CP_VER }}
+    #     CIBW_BUILD="$CP_VER-manylinux_x86_64"
+    #     if [[ "$CP_VER" != pp* ]]; then
+    #       CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_x86_64"
+    #     fi
+    #     echo "CIBW_BUILD: $CIBW_BUILD"
+    #     echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
       
-    - name: Make CIBW_BUILD list (Linux 32-bit)
-      if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 32
-      run: |
-        CP_VER=${{ env.CP_VER }}
-        CIBW_BUILD="$CP_VER-manylinux_i686"
-        echo "CIBW_BUILD: $CIBW_BUILD"
-        echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
+    # - name: Make CIBW_BUILD list (Linux 32-bit)
+    #   if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 32
+    #   run: |
+    #     CP_VER=${{ env.CP_VER }}
+    #     CIBW_BUILD="$CP_VER-manylinux_i686"
+    #     echo "CIBW_BUILD: $CIBW_BUILD"
+    #     echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
 
-    - name: Make CIBW_BUILD list (Windows)
-      if: startsWith(matrix.os, 'windows-')
-      run: echo "CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
+    # - name: Make CIBW_BUILD list (Windows)
+    #   if: startsWith(matrix.os, 'windows-')
+    #   run: CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
 
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -175,13 +176,13 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         # See CIBW_ARCHS and other build selectors at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
-        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+        CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_ENVIRONMENT_MACOS: |
           MACOSX_DEPLOYMENT_TARGET=10.9
           PATH="$HOME/.cargo/bin:$PATH"
           CC=/usr/bin/clang
           CXX=/usr/bin/clang++
-        CIBW_ARCHS_LINUX: "auto aarch64"
+        CIBW_ARCHS_LINUX: "auto"
         CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
         CIBW_BEFORE_BUILD_LINUX: |
           pip install --upgrade setuptools-rust
@@ -189,6 +190,7 @@ jobs:
         # It is needed to install Rust for Linux,
         # because cibuildwheel on Linux runs inside a container
         # and the container does not have Rust.
+        CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
     - name: Store artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -88,6 +88,8 @@ jobs:
           bitness: 32
         - os: macos-latest
           python-version: "3.7"
+        - os: macos-latest
+          python-version: "pypy3.7"
         # - python-version: "pypy3.10"
         #   bitness: 32
         # - python-version: "pypy3.9"
@@ -145,9 +147,6 @@ jobs:
       run: |
         CP_VER=${{ env.CP_VER }}
         CIBW_BUILD="$CP_VER-manylinux_i686"
-        if [[ "$CP_VER" != pp* ]]; then
-          CIBW_BUILD="$CIBW_BUILD $CP_VER-musllinux_i686"
-        fi
         echo "CIBW_BUILD: $CIBW_BUILD"
         echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
 
@@ -176,11 +175,13 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         # See build selector name at:
         # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
         CIBW_ENVIRONMENT_MACOS: |
           MACOSX_DEPLOYMENT_TARGET=10.9
           PATH="$HOME/.cargo/bin:$PATH"
           CC=/usr/bin/clang
           CXX=/usr/bin/clang++
+        CIBW_ARCHS_LINUX: "auto aarch64"
         CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
         CIBW_BEFORE_BUILD_LINUX: |
           pip install --upgrade setuptools-rust

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -71,12 +71,6 @@ jobs:
         python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "pypy3.10", "pypy3.9", "pypy3.8", "pypy3.7"]
         bitness: [64, 32]
         include:
-        - os: macos-latest
-          bitness: 64
-          platform_id: macosx_x86_64
-        - os: macos-latest
-          bitness: 64
-          platform_id: macosx_arm64
         - os: windows-latest
           bitness: 64
           platform_id: win_amd64
@@ -90,10 +84,6 @@ jobs:
           python-version: "3.7"
         - os: macos-latest
           python-version: "pypy3.7"
-        # - python-version: "pypy3.10"
-        #   bitness: 32
-        # - python-version: "pypy3.9"
-        #   bitness: 32
     env:
       CP_VER: ""
       CIBW_BUILD: ""
@@ -113,6 +103,7 @@ jobs:
         fi
         echo "Python version: $CP_VER"
         echo "CP_VER=$CP_VER" >> $GITHUB_ENV
+
     - name: Make Python implementation ID (Windows)
       id: convert-version-id-win
       if: startsWith(matrix.os, 'windows-')
@@ -127,9 +118,9 @@ jobs:
         echo "Python version: $CP_VER"
         echo "CP_VER=$CP_VER" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-    - name: Make CIBW_BUILD list (non-Linux)
-      if: startsWith(matrix.os, 'ubuntu-') == false
-      run: echo "CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
+    - name: Make CIBW_BUILD list (macOS)
+      if: startsWith(matrix.os, 'macos-')
+      run: echo "CIBW_BUILD=${{ env.CP_VER }}-macosx*" >> $GITHUB_ENV
 
     - name: Make CIBW_BUILD list (Linux 64-bit)
       if: startsWith(matrix.os, 'ubuntu-') && matrix.bitness == 64
@@ -149,6 +140,10 @@ jobs:
         CIBW_BUILD="$CP_VER-manylinux_i686"
         echo "CIBW_BUILD: $CIBW_BUILD"
         echo "CIBW_BUILD=$CIBW_BUILD" >> $GITHUB_ENV
+
+    - name: Make CIBW_BUILD list (Windows)
+      if: startsWith(matrix.os, 'windows-')
+      run: echo "CIBW_BUILD=${{ env.CP_VER }}-${{ matrix.platform_id }}" >> $GITHUB_ENV
 
     - name: Checkout source code
       uses: actions/checkout@v4


### PR DESCRIPTION
Massive wheel building - 67 in total across Python 3.7-3.13, PyPy 3.7-3.10 on macOS, Linuxes, and Windows.

### macOS

On x86_64 and arm64.

20 wheels produced in 6 minutes:

1. nlpo3-1.3.1-cp310-cp310-macosx_10_9_x86_64.whl           703 kB
1. nlpo3-1.3.1-cp310-cp310-macosx_11_0_arm64.whl            663 kB
1. nlpo3-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl           703 kB
1. nlpo3-1.3.1-cp311-cp311-macosx_11_0_arm64.whl            663 kB
1. nlpo3-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl          703 kB
1. nlpo3-1.3.1-cp312-cp312-macosx_11_0_arm64.whl            663 kB
1. nlpo3-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl          702 kB
1. nlpo3-1.3.1-cp313-cp313-macosx_11_0_arm64.whl            662 kB
1. nlpo3-1.3.1-cp37-cp37m-macosx_10_9_x86_64.whl            703 kB
1. nlpo3-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl             703 kB
1. nlpo3-1.3.1-cp38-cp38-macosx_11_0_arm64.whl              663 kB
1. nlpo3-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl             703 kB
1. nlpo3-1.3.1-cp39-cp39-macosx_11_0_arm64.whl              663 kB
1. nlpo3-1.3.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl   705 kB
1. nlpo3-1.3.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl     664 kB
1. nlpo3-1.3.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl      707 kB
1. nlpo3-1.3.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl      704 kB
1. nlpo3-1.3.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl       664 kB
1. nlpo3-1.3.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl     704 kB
1. nlpo3-1.3.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl       664 kB


### Linux

On {manylinux, musllinux} - {x86_64, i686}.

29 wheels produced in 12 minutes:

1. nlpo3-1.3.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl              800 kB
1. nlpo3-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl          800 kB
1. nlpo3-1.3.1-cp310-cp310-musllinux_1_2_x86_64.whl                                860 kB
1. nlpo3-1.3.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl              800 kB
1. nlpo3-1.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl          800 kB
1. nlpo3-1.3.1-cp311-cp311-musllinux_1_2_x86_64.whl                                860 kB
1. nlpo3-1.3.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl              800 kB
1. nlpo3-1.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl          800 kB
1. nlpo3-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl                                860 kB
1. nlpo3-1.3.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl              799 kB
1. nlpo3-1.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl          800 kB
1. nlpo3-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl                                859 kB
1. nlpo3-1.3.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl               800 kB
1. nlpo3-1.3.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl           800 kB
1. nlpo3-1.3.1-cp37-cp37m-musllinux_1_2_x86_64.whl                                 860 kB
1. nlpo3-1.3.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl                801 kB
1. nlpo3-1.3.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl            800 kB
1. nlpo3-1.3.1-cp38-cp38-musllinux_1_2_x86_64.whl                                  860 kB
1. nlpo3-1.3.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl                801 kB
1. nlpo3-1.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl            800 kB
1. nlpo3-1.3.1-cp39-cp39-musllinux_1_2_x86_64.whl                                  860 kB
1. nlpo3-1.3.1-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl       802 kB
1. nlpo3-1.3.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   801 kB
1. nlpo3-1.3.1-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl         805 kB
1. nlpo3-1.3.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     805 kB
1. nlpo3-1.3.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl         802 kB
1. nlpo3-1.3.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     802 kB
1. nlpo3-1.3.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl         803 kB
1. nlpo3-1.3.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     802 kB

### Windows

On win_amd64 and win32.

18 wheels produced in 15 minutes:

1. nlpo3-1.3.1-cp310-cp310-win32.whl              505 kB
1. nlpo3-1.3.1-cp310-cp310-win_amd64.whl          569 kB
1. nlpo3-1.3.1-cp311-cp311-win32.whl              505 kB
1. nlpo3-1.3.1-cp311-cp311-win_amd64.whl          569 kB
1. nlpo3-1.3.1-cp312-cp312-win32.whl              505 kB
1. nlpo3-1.3.1-cp312-cp312-win_amd64.whl          569 kB
1. nlpo3-1.3.1-cp313-cp313-win32.whl              504 kB
1. nlpo3-1.3.1-cp313-cp313-win_amd64.whl          568 kB
1. nlpo3-1.3.1-cp37-cp37m-win32.whl               505 kB
1. nlpo3-1.3.1-cp37-cp37m-win_amd64.whl           568 kB
1. nlpo3-1.3.1-cp38-cp38-win32.whl                505 kB
1. nlpo3-1.3.1-cp38-cp38-win_amd64.whl            569 kB
1. nlpo3-1.3.1-cp39-cp39-win32.whl                505 kB
1. nlpo3-1.3.1-cp39-cp39-win_amd64.whl            569 kB
1. nlpo3-1.3.1-pp310-pypy310_pp73-win_amd64.whl   570 kB
1. nlpo3-1.3.1-pp37-pypy37_pp73-win_amd64.whl     571 kB
1. nlpo3-1.3.1-pp38-pypy38_pp73-win_amd64.whl     570 kB
1. nlpo3-1.3.1-pp39-pypy39_pp73-win_amd64.whl     570 kB
