### PR TITLE
Replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -117,7 +117,7 @@ jobs:
         CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
     - name: Store artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl
 
@@ -139,7 +139,7 @@ jobs:
         cd nlpo3-python
         bash ../build_tools/github/build_source.sh
     - name: Store artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         path: nlpo3-python/dist/*.tar.gz
 
@@ -153,7 +153,7 @@ jobs:
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     steps:
     - name: Retrieve artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: dist

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -22,8 +22,7 @@ on:
     - '.github/workflows/build-python-wheels.yml'
   release:
     types: [published]
-  # Manual run
-  workflow_dispatch: {}
+  workflow_dispatch: {}  # manual run
 
 jobs:
   echo_github_env:
@@ -118,7 +117,7 @@ jobs:
         CIBW_ARCHS_WINDOWS: "AMD64 x86"
 
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
 
@@ -140,7 +139,7 @@ jobs:
         cd nlpo3-python
         bash ../build_tools/github/build_source.sh
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: nlpo3-python/dist/*.tar.gz
 
@@ -154,7 +153,7 @@ jobs:
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'v')
     steps:
     - name: Retrieve artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -9,5 +9,5 @@ COMMIT_MSG=$(git log --no-merges -1 --oneline)
 if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ||
       "$GITHUB_EVENT_NAME" == "release" ||
       "$COMMIT_MSG" =~ "[cd build]" ]]; then
-    echo "::set-output name=build::true"
+    echo "build=true" >> $GITHUB_OUTPUT
 fi

--- a/nlpo3-python/Cargo.toml
+++ b/nlpo3-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nlpo3-python"
-version = "1.3.1"
+version = "1.3.2-dev"
 edition = "2018"
 license = "Apache-2.0"
 authors = [

--- a/nlpo3-python/pyproject.toml
+++ b/nlpo3-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nlpo3"
-version = "1.3.1"
+version = "1.3.2-dev"
 description = "Python binding for nlpO3 Thai language processing library in Rust"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/nlpo3-python/setup.cfg
+++ b/nlpo3-python/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = nlpo3
-version = 1.3.1
+version = 1.3.2-dev
 description = Python binding for nlpO3 Thai language processing library
 long_description =
     Python binding for nlpO3, a Thai natural language processing library in Rust.


### PR DESCRIPTION
Fix deprecation of set-output, replace with >> $GITHUB_OUTPUT

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/